### PR TITLE
Patch MSVC-specific code to permit cross-compilation with mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ add_library(SuperBLT SHARED ${sources})
 target_compile_options(SuperBLT PRIVATE
 	-DCURL_STATICLIB
 	-DSUBHOOK_STATIC
-	-DAL_LIBTYPE_STATIC
 	-DWIN32_LEAN_AND_MEAN
 	-DNOMINMAX # Make std::min and std::max usable
 )
@@ -318,6 +317,7 @@ set(ALSOFT_INSTALL_HRTF_DATA OFF)
 set(ALSOFT_INSTALL_AMBDEC_PRESETS OFF)
 add_subdirectory(lib/sys/openalsoft EXCLUDE_FROM_ALL)
 target_link_libraries(OpenAL PRIVATE winmm.lib) # Not set up by default?
+target_compile_options(OpenAL PUBLIC -DAL_LIBTYPE_STATIC) # Required as well as LIBTYPE=STATIC to prevent OpenAL from generating a DllMain
 target_link_libraries(SuperBLT OpenAL)
 
 #### CURL ####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ list(TRANSFORM mxml_sources PREPEND lib/mxml/)
 add_library(mxml STATIC ${mxml_sources})
 target_include_directories(mxml PRIVATE lib/configs/mxml)
 target_compile_options(mxml PRIVATE -D_CRT_SECURE_NO_WARNINGS)
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # Allows compiling with non-Microsoft compilers. Not from the native Linux build.
 	target_compile_options(mxml PRIVATE -Wno-int-conversion -Wno-implicit-function-declaration)
 endif()
 target_include_directories(mxml PUBLIC lib/mxml)
@@ -134,7 +134,7 @@ target_compile_options(SuperBLT PRIVATE
 	-DNOMINMAX # Make std::min and std::max usable
 )
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # Allows compiling with non-Microsoft compilers. Not from the native Linux build.
 	find_package(Threads REQUIRED)
 	set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 	target_compile_options(SuperBLT PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # Allows compiling with non-Micro
 	find_package(Threads REQUIRED)
 	set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 	target_compile_options(SuperBLT PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
-	target_include_directories(SuperBLT PUBLIC lib/mldsa-native lib/sys/openalsoft/include)
 	target_link_libraries(SuperBLT -static -static-libgcc -static-libstdc++ Threads::Threads)
 endif()
 
@@ -419,5 +418,8 @@ target_link_libraries(SuperBLT cJSON)
 add_library(mldsa_native STATIC
 	lib/mldsa-native/mldsa/mldsa_native.c
 )
-target_include_directories(mldsa_native PUBLIC lib/mldsa-native/mldsa)
+target_include_directories(mldsa_native
+		PRIVATE lib/mldsa-native/mldsa
+		INTERFACE lib/mldsa-native
+)
 target_link_libraries(SuperBLT mldsa_native)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,8 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") # Allows compiling with non-Micro
 	set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 	target_compile_options(SuperBLT PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
 	target_link_libraries(SuperBLT -static -static-libgcc -static-libstdc++ Threads::Threads)
+elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+	target_compile_options(SuperBLT PRIVATE $<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>)
 endif()
 
 # General optimisation breaks calls to certain lua functions, so replace it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ list(TRANSFORM mxml_sources PREPEND lib/mxml/)
 add_library(mxml STATIC ${mxml_sources})
 target_include_directories(mxml PRIVATE lib/configs/mxml)
 target_compile_options(mxml PRIVATE -D_CRT_SECURE_NO_WARNINGS)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	target_compile_options(mxml PRIVATE -Wno-int-conversion -Wno-implicit-function-declaration)
+endif()
 target_include_directories(mxml PUBLIC lib/mxml)
 
 file(GLOB_RECURSE wren_sources
@@ -127,9 +130,18 @@ add_library(SuperBLT SHARED ${sources})
 target_compile_options(SuperBLT PRIVATE
 	-DCURL_STATICLIB
 	-DSUBHOOK_STATIC
+	-DAL_LIBTYPE_STATIC
 	-DWIN32_LEAN_AND_MEAN
 	-DNOMINMAX # Make std::min and std::max usable
 )
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	find_package(Threads REQUIRED)
+	set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+	target_compile_options(SuperBLT PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fpermissive>)
+	target_include_directories(SuperBLT PUBLIC lib/mldsa-native lib/sys/openalsoft/include)
+	target_link_libraries(SuperBLT -static -static-libgcc -static-libstdc++ Threads::Threads)
+endif()
 
 # General optimisation breaks calls to certain lua functions, so replace it.
 # We statically link to reduce dependencies
@@ -270,6 +282,9 @@ target_compile_definitions(psl PRIVATE
 )
 target_compile_definitions(psl PUBLIC PSL_STATIC)
 target_compile_options(psl PRIVATE -D_CRT_SECURE_NO_WARNINGS -DENABLE_BUILTIN)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+	target_compile_options(psl PRIVATE -Wno-int-conversion -Wno-implicit-function-declaration)
+endif()
 target_include_directories(psl PUBLIC "${PSL_BINARY_DIR}")
 add_dependencies(psl generate_psl_files)
 
@@ -404,6 +419,5 @@ target_link_libraries(SuperBLT cJSON)
 add_library(mldsa_native STATIC
 	lib/mldsa-native/mldsa/mldsa_native.c
 )
-target_include_directories(mldsa_native PUBLIC lib/mldsa-native)
-
+target_include_directories(mldsa_native PUBLIC lib/mldsa-native lib/mldsa-native/mldsa)
 target_link_libraries(SuperBLT mldsa_native)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,5 +419,5 @@ target_link_libraries(SuperBLT cJSON)
 add_library(mldsa_native STATIC
 	lib/mldsa-native/mldsa/mldsa_native.c
 )
-target_include_directories(mldsa_native PUBLIC lib/mldsa-native lib/mldsa-native/mldsa)
+target_include_directories(mldsa_native PUBLIC lib/mldsa-native/mldsa)
 target_link_libraries(SuperBLT mldsa_native)

--- a/lib/ak_headers/include/AK/SoundEngine/Platforms/Windows/AkAtomic.h
+++ b/lib/ak_headers/include/AK/SoundEngine/Platforms/Windows/AkAtomic.h
@@ -28,7 +28,7 @@ the specific language governing permissions and limitations under the License.
 
 #pragma once
 
-#include <Windows.h>
+#include <windows.h>
 
 // Sleep of 1 is as close as we can get on Microsoft platforms
 // SwitchToThread() is liable to cause the current thread to be unscheduled for 10-30ms

--- a/lib/ak_headers/include/AK/Tools/Win32/AkPlatformFuncs.h
+++ b/lib/ak_headers/include/AK/Tools/Win32/AkPlatformFuncs.h
@@ -270,6 +270,8 @@ namespace AKPLATFORM
 		info.dwThreadID = in_dwThreadID;
 		info.dwFlags = 0;
 
+		// Only raise MS Exceptions if on MSVC
+#ifdef _MSC_VER && !__INTEL_COMPILER
 		__try
 		{
 			RaiseException( MS_VC_EXCEPTION, 0, sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info );
@@ -278,6 +280,9 @@ namespace AKPLATFORM
 		__except(EXCEPTION_CONTINUE_EXECUTION)
 		{
 		}
+#else
+		abort();
+#endif
 	}
 
 	/// Platform Independent Helper

--- a/lib/ak_headers/include/AK/Tools/Win32/AkPlatformFuncs.h
+++ b/lib/ak_headers/include/AK/Tools/Win32/AkPlatformFuncs.h
@@ -271,7 +271,7 @@ namespace AKPLATFORM
 		info.dwFlags = 0;
 
 		// Only raise MS Exceptions if on MSVC
-#ifdef _MSC_VER && !__INTEL_COMPILER
+#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 		__try
 		{
 			RaiseException( MS_VC_EXCEPTION, 0, sizeof(info)/sizeof(ULONG_PTR), (ULONG_PTR*)&info );

--- a/lib/ak_headers/include/AK/Tools/Win32/AkPlatformFuncs.h
+++ b/lib/ak_headers/include/AK/Tools/Win32/AkPlatformFuncs.h
@@ -39,6 +39,7 @@ the specific language governing permissions and limitations under the License.
 #include <math.h>
 #endif // _WIN64
 #include <intrin.h>
+#include <processthreadsapi.h>
 
 #if defined(AK_XBOXSERIESX)
 #include <ammintrin.h>
@@ -270,7 +271,8 @@ namespace AKPLATFORM
 		info.dwThreadID = in_dwThreadID;
 		info.dwFlags = 0;
 
-		// Only raise MS Exceptions if on MSVC
+		// Only raise MS Exceptions if on MSVC.
+		// Might be better to use the current MS recommendation https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setthreaddescription
 #if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 		__try
 		{
@@ -281,7 +283,21 @@ namespace AKPLATFORM
 		{
 		}
 #else
-		abort();
+		HANDLE hThread = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | PROCESS_SET_LIMITED_INFORMATION, false, in_dwThreadID);
+		PWSTR wideName;
+		{
+			int newLen = MultiByteToWideChar(CP_THREAD_ACP, 0, in_szThreadName, -1, nullptr, 0);
+			if (newLen <= 0)
+			{
+				// Something is up, not worth bothering.
+				goto cancel;
+			}
+			wideName = static_cast<PWSTR>(malloc((newLen + 1) * sizeof(WCHAR)));
+			MultiByteToWideChar(CP_THREAD_ACP, 0, in_szThreadName, -1, wideName, newLen + 1);
+		}
+		SetThreadDescription(hThread, wideName);
+		cancel:
+		CloseHandle(hThread);
 #endif
 	}
 

--- a/mingw-w64-toolchain.cmake
+++ b/mingw-w64-toolchain.cmake
@@ -32,10 +32,3 @@ set(ALSOFT_BACKEND_PIPEWIRE 0)
 # CMake determines how to examine dependencies based on the *host* system, leading to
 # a `file unknown error` unless the target platform is explicitly specified.
 set(CMAKE_GET_RUNTIME_DEPENDENCIES_PLATFORM "windows+pe")
-
-# Qt4 tools
-SET(QT_QMAKE_EXECUTABLE ${HOST}-qmake)
-SET(QT_MOC_EXECUTABLE ${HOST}-moc)
-SET(QT_RCC_EXECUTABLE ${HOST}-rcc)
-SET(QT_UIC_EXECUTABLE ${HOST}-uic)
-SET(QT_LRELEASE_EXECUTABLE ${HOST}-lrelease)

--- a/mingw-w64-toolchain.cmake
+++ b/mingw-w64-toolchain.cmake
@@ -1,0 +1,41 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(HOST "x86_64-w64-mingw32")
+
+# specify the cross compiler
+set(CMAKE_C_COMPILER "${HOST}-gcc")
+set(CMAKE_CXX_COMPILER "${HOST}-g++")
+set(CMAKE_RC_COMPILER "${HOST}-windres")
+set(CMAKE_ASM_MASM_COMPILER jwasm -win64 -e999)
+
+# where is the target environment
+set(CMAKE_FIND_ROOT_PATH "/usr/${HOST}")
+#set(CMAKE_SYSROOT "/usr/${HOST}")
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH 0)
+
+# search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+set(CMAKE_CXX_FLAGS_INIT "-I${CMAKE_FIND_ROOT_PATH}/include")
+
+# Disable it detecting my system pkg-config
+set(PKG_CONFIG_LIBDIR "${CMAKE_FIND_ROOT_PATH}/lib/pkgconfig")
+set(PKG_CONFIG_PATH "")
+
+set(ALSOFT_EXAMPLES OFF)
+set(ALSOFT_BACKEND_PIPEWIRE 0)
+
+# CMake determines how to examine dependencies based on the *host* system, leading to
+# a `file unknown error` unless the target platform is explicitly specified.
+set(CMAKE_GET_RUNTIME_DEPENDENCIES_PLATFORM "windows+pe")
+
+# Qt4 tools
+SET(QT_QMAKE_EXECUTABLE ${HOST}-qmake)
+SET(QT_MOC_EXECUTABLE ${HOST}-moc)
+SET(QT_RCC_EXECUTABLE ${HOST}-rcc)
+SET(QT_UIC_EXECUTABLE ${HOST}-uic)
+SET(QT_LRELEASE_EXECUTABLE ${HOST}-lrelease)

--- a/src/assets/convert.h
+++ b/src/assets/convert.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 #include <vector>
 
 #include "subhook.h"

--- a/src/console/console.cpp
+++ b/src/console/console.cpp
@@ -1,6 +1,4 @@
 #include "console.h"
-// This is unix-only and so doesn't actually do anything anymore
-//#include <FCNTL.H>
 #include <conio.h>
 #include <io.h>
 #include <iostream>

--- a/src/console/console.cpp
+++ b/src/console/console.cpp
@@ -1,5 +1,6 @@
 #include "console.h"
-#include <FCNTL.H>
+// This is unix-only and so doesn't actually do anything anymore
+//#include <FCNTL.H>
 #include <conio.h>
 #include <io.h>
 #include <iostream>

--- a/src/dbutil/Archive.cpp
+++ b/src/dbutil/Archive.cpp
@@ -15,9 +15,9 @@ Archive* Archive::Constructor(Archive* archive, const std::string& name, BLTAbst
 
 	archive->position = pos;
 	archive->length = len;
-	archive->probablyReadCounter = 0i64;
+	archive->probablyReadCounter = 0;
 	archive->probablyNotLoadedFlag = probablyNotLoadedFlag;
-	archive->maybeCompressedSize = 0i64;
+	archive->maybeCompressedSize = 0;
 
 #pragma warning(suppress : 6031) // Complains about not using the return data.
 	InitializeCriticalSectionAndSpinCount(&archive->lock, 4000);

--- a/src/dbutil/Archive.h
+++ b/src/dbutil/Archive.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <windows.h>
 

--- a/src/http/blt_downloader.cpp
+++ b/src/http/blt_downloader.cpp
@@ -3,7 +3,7 @@
 #include "util/util.h"
 #include <curl/curl.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 static const char* DOWNLOAD_URL = "https://api.modworkshop.net/mods/58345/download";
 static const char* OUT_FILE_NAME = "blt_basemod_download.zip";

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -6,7 +6,7 @@
 #include "updater/updater.h"
 #include "util/util.h"
 
-#include <Windows.h>
+#include <windows.h>
 #include <filesystem>
 #include <format>
 #include <fstream>

--- a/src/signatures/sigdef.h
+++ b/src/signatures/sigdef.h
@@ -9,7 +9,7 @@
 	SignatureSearch name##search(#name, &name, signature, mask, offset);
 
 #define CREATE_CALLABLE_CLASS_SIGNATURE(name, retn, signature, mask, offset, ...) \
-	typedef retn(__fastcall* name##ptr)(void*, __VA_ARGS__);                      \
+	typedef retn(__fastcall* name##ptr)(void* __VA_OPT__(,) __VA_ARGS__);                      \
 	name##ptr name = NULL;                                                        \
 	SignatureSearch name##search(#name, &name, signature, mask, offset);
 
@@ -21,7 +21,7 @@
 	extern name##ptr name;
 
 #define CREATE_CALLABLE_CLASS_SIGNATURE(name, retn, signature, mask, offset, ...) \
-	typedef retn(__fastcall* name##ptr)(void*, __VA_ARGS__);                      \
+	typedef retn(__fastcall* name##ptr)(void* __VA_OPT__(,) __VA_ARGS__);                      \
 	extern name##ptr name;
 
 #endif

--- a/src/signatures/signatures.cpp
+++ b/src/signatures/signatures.cpp
@@ -1,6 +1,6 @@
 // We specifically need the windows and psapi imports in this order
 // clang-format off
-#include <Windows.h>
+#include <windows.h>
 #include <Psapi.h>
 // clang-format on
 

--- a/src/tweaker/wren_lua_interface.cpp
+++ b/src/tweaker/wren_lua_interface.cpp
@@ -8,7 +8,7 @@
 
 #include <map>
 #include <mutex>
-#include <string.h>
+#include <string>
 
 #include "wrenloader.h"
 

--- a/src/util/native_files.cpp
+++ b/src/util/native_files.cpp
@@ -2,7 +2,7 @@
 // Some other stuff might be aswell, but this is rather desperately windows only.
 
 #include "util/util.h"
-#include <Windows.h>
+#include <windows.h>
 #include <cstdio>
 #include <tchar.h>
 #include <strsafe.h>

--- a/src/util/native_files.cpp
+++ b/src/util/native_files.cpp
@@ -3,9 +3,9 @@
 
 #include "util/util.h"
 #include <Windows.h>
-#include <stdio.h>
-#include <strsafe.h>
+#include <cstdio>
 #include <tchar.h>
+#include <strsafe.h>
 
 #include <fstream>
 #include <streambuf>

--- a/src/util/util.cpp
+++ b/src/util/util.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include <Windows.h>
+#include <windows.h>
 #include <bcrypt.h>
 
 namespace raidhook

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -3,6 +3,7 @@
 
 #include "lua.h"
 #include <exception>
+#include <memory>
 #include <platform.h>
 #include <sstream>
 #include <string>

--- a/src/xaudio/XAudioInternal.h
+++ b/src/xaudio/XAudioInternal.h
@@ -11,9 +11,9 @@
 #include "lua.h"
 #include "util/util.h"
 
-#include <al/al.h>
-#include <al/alc.h>
-#include <al/alext.h>
+#include <AL/al.h>
+#include <AL/alc.h>
+#include <AL/alext.h>
 
 using namespace std;
 


### PR DESCRIPTION
This patch makes some minor changes across the codebase to lessen the impact of compiler specific code.

In particular, it:
- Provides a CMake Toolchain file (that can be applied with `-DCMAKE_TOOLCHAIN_FILE=toolchain-mingw64.cmake`), that makes configuration changes for MinGW.
- A few sections of "GNU"-specific code in the main `CMakeLists.txt`, where changes are required that cannot be made from within the toolchain file.
- More consistent case in `#include`s to allow for a case-insensitive filesystem.
- Explicit inclusion of some headers that were added automatically by MSVC
- Use of `__VA_OPT__` to prevent a non-compliant trailing comma in the signature resolution macro.
- A couple of small changes to MSVC-specific semantics.

This *should* have no impact on Windows builds, but I don't have a Windows system to test with.
Please also let me know if there are any code-style issues or similar.