### PR TITLE
Fix .stream overrides to zero-latency sounds (AkTlsSetValue crashes)

### DIFF
--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -34,6 +34,9 @@ DECLARE_PASSTHROUGH(try_open_property_match_resolver)
 static subhook::Hook WwDevice_loadBankIdstringDetour;
 static subhook::Hook WwDevice_idToEntryDetour;
 
+static subhook::Hook CAkSrcFileBase_StartStreamDetour;
+std::unordered_set<uint32_t> overridenStreams, playedStreams;
+
 // Access happens on two different threads
 std::mutex customWwiseMapsMutex;
 std::map<blt::idstring, std::string> customWwiseSoundbankNames;
@@ -52,6 +55,21 @@ class sound_WwDevice
 	virtual SoundBank* load_bank_string(const char* bank, bool async) = 0;
 
   public:
+};
+
+struct AkMediaInformation
+{
+	uint32_t sourceID;
+	uint32_t uFileID;
+	uint32_t inMemoryMediaSize;
+
+	uint32_t bIsLanguageSpecific : 1;
+	uint32_t bPrefetch : 1;
+	uint32_t Type : 5;
+	uint32_t bHasSource : 1;
+	uint32_t bExternallySupplied : 1;
+	uint32_t bUseFilenameString : 1;
+	uint32_t bNonCachable : 1;
 };
 
 SoundBank* sound_WwDevice__load_bank_idstring_h(sound_WwDevice* this_, idstr bank, bool async)
@@ -94,7 +112,40 @@ idstr* sound_WwDevice__id_to_entry_h(sound_WwDevice* this_, idstr* result, unsig
 	return result;
 }
 
+void* CAkSrcFileBase_StartStream_h(void* this_, void* in_bufSettings)
+{
+	subhook::ScopedHookRemove scoped_remove(&CAkSrcFileBase_StartStreamDetour);
 
+	void* m_pCtx = *(void**)((char*)this_ + 24);
+	void* m_pSource = *(void**)((char*)m_pCtx + 672);
+
+	// struct AkSrcTypeInfo { // m_sSrcTypeInfo
+	//		AkMediaInformation mediaInfo;
+	//		...
+	// }
+	// struct CAkSource { // m_pSource
+	//		AkSrcTypeInfo m_sSrcTypeInfo
+	//		...
+	// }
+	AkMediaInformation* mediaInfo = (AkMediaInformation*)((char*)m_pSource);
+
+	// Javgarag: we need a playedStreams set so that we get a chance of adding the file to overridenStreams (it loads after this call) and so that we don't crash the first time for not disabling the prefetch
+	// disabling prefetch at least once, even for vanilla streams, is inevitable for our purposes
+	if (mediaInfo->bPrefetch) 
+	{
+		if (!playedStreams.contains(mediaInfo->sourceID) || overridenStreams.contains(mediaInfo->sourceID))
+		{
+			mediaInfo->bPrefetch = false;
+		}	
+	}
+
+	if (!playedStreams.contains(mediaInfo->sourceID))
+		playedStreams.insert(mediaInfo->sourceID);
+
+	auto ret = CAkSrcFileBase__StartStream(this_, in_bufSettings);
+	mediaInfo->bPrefetch = true;
+	return ret;
+}
 
 void blt::win32::InitAssets()
 {
@@ -116,6 +167,8 @@ void blt::win32::InitAssets()
 	
 	WwDevice_loadBankIdstringDetour.Install(sound_WwDevice__load_bank_idstring, &sound_WwDevice__load_bank_idstring_h, HOOK_FLAG);
 	WwDevice_idToEntryDetour.Install(sound_WwDevice__id_to_entry, &sound_WwDevice__id_to_entry_h, HOOK_FLAG);
+
+	CAkSrcFileBase_StartStreamDetour.Install(CAkSrcFileBase__StartStream, &CAkSrcFileBase_StartStream_h, HOOK_FLAG);
 }
 
 
@@ -156,6 +209,14 @@ void blt::platform::wwise::UnregisterCustomSoundbank(const char* dbPath)
 		customWwiseSoundbankNames.erase(hashedPath);
 	if (customWwiseIdToEntryNames.find(wwiseHash) != customWwiseIdToEntryNames.end())
 		customWwiseIdToEntryNames.erase(wwiseHash);
+}
+
+void blt::platform::wwise::RegisterOverridenStreamedWem(unsigned int wemId)
+{
+	if (overridenStreams.contains(wemId))
+		return;
+
+	overridenStreams.insert(wemId);
 }
 
 void blt::platform::wwise::RegisterCustomStreamedWemPath(unsigned int wemId, const char* dbPath)

--- a/src/assets/assets.cpp
+++ b/src/assets/assets.cpp
@@ -35,7 +35,7 @@ static subhook::Hook WwDevice_loadBankIdstringDetour;
 static subhook::Hook WwDevice_idToEntryDetour;
 
 static subhook::Hook CAkSrcFileBase_StartStreamDetour;
-std::unordered_set<uint32_t> overridenStreams, playedStreams;
+std::unordered_set<uint32_t> overridenStreams, playedPrefetchStreams;
 
 // Access happens on two different threads
 std::mutex customWwiseMapsMutex;
@@ -133,17 +133,20 @@ void* CAkSrcFileBase_StartStream_h(void* this_, void* in_bufSettings)
 	// disabling prefetch at least once, even for vanilla streams, is inevitable for our purposes
 	if (mediaInfo->bPrefetch) 
 	{
-		if (!playedStreams.contains(mediaInfo->sourceID) || overridenStreams.contains(mediaInfo->sourceID))
+		if (!playedPrefetchStreams.contains(mediaInfo->sourceID) || overridenStreams.contains(mediaInfo->sourceID))
 		{
 			mediaInfo->bPrefetch = false;
+
+			if (!playedPrefetchStreams.contains(mediaInfo->sourceID))
+				playedPrefetchStreams.insert(mediaInfo->sourceID);
 		}	
 	}
 
-	if (!playedStreams.contains(mediaInfo->sourceID))
-		playedStreams.insert(mediaInfo->sourceID);
-
 	auto ret = CAkSrcFileBase__StartStream(this_, in_bufSettings);
-	mediaInfo->bPrefetch = true;
+
+	if (!overridenStreams.contains(mediaInfo->sourceID) && playedPrefetchStreams.contains(mediaInfo->sourceID))
+		mediaInfo->bPrefetch = true;
+	
 	return ret;
 }
 

--- a/src/assets/assets_game.cpp
+++ b/src/assets/assets_game.cpp
@@ -89,6 +89,7 @@ static void ConvertData(Archive* archive, const ConversionFn& conversionFn)
 	archive->maybeCompressedSize = 0;
 }
 
+const blt::idstring IDS_STREAM = blt::idstring_hash("stream");
 const blt::idstring IDS_BNK = blt::idstring_hash("bnk");
 const blt::idstring IDS_ANIMATION = blt::idstring_hash("animation");
 const blt::idstring IDS_FONT = blt::idstring_hash("font");
@@ -157,6 +158,16 @@ static void hook_load(try_open_t orig, subhook::Hook& hook, void* this_, Archive
 
 		// Don't attempt any further format conversion.
 		return;
+	}
+
+	if (*type == IDS_STREAM)
+	{
+		// Javgarag: We need this to selectively disable prefetching on overriden streams, otherwise pitch issues/crashes will happen
+		std::string filePath = archive->name.ToCXX();
+		size_t start = filePath.find_last_of("/") + 1;
+		size_t end = filePath.find(".stream", start);
+
+		blt::platform::wwise::RegisterOverridenStreamedWem(std::stoul(filePath.substr(start, end - start)));
 	}
 
 	if (*type == IDS_BNK)

--- a/src/platform.h
+++ b/src/platform.h
@@ -68,6 +68,7 @@ namespace blt
 			void RegisterCustomSoundbank(const char* dbPath);
 			void UnregisterCustomSoundbank(const char* dbPath);
 
+			void RegisterOverridenStreamedWem(unsigned int wemId);
 			void RegisterCustomStreamedWemPath(unsigned int wemId, const char* dbPath);
 			void UnregisterCustomStreamedWemPath(unsigned int wemId);
 		};

--- a/src/signatures/sigdef_game.h
+++ b/src/signatures/sigdef_game.h
@@ -18,6 +18,8 @@ class idstr {public: unsigned __int64 _id;};
 CREATE_CALLABLE_CLASS_SIGNATURE(sound_WwDevice__load_bank_idstring, SoundBank*, "\x48\x89\x5C\x24\x00\x48\x89\x74\x24\x00\x48\x89\x7C\x24\x00\x4C\x89\x74\x24\x00\x41\x57\x48\x83\xEC\x00\x45\x0F\xB6\xF8", "xxxx?xxxx?xxxx?xxxx?xxxxx?xxxx", 0, idstr bank, bool async);
 CREATE_CALLABLE_CLASS_SIGNATURE(sound_WwDevice__id_to_entry, idstr*, "\x48\x89\x5C\x24\x00\x48\x89\x74\x24\x00\x48\x89\x7C\x24\x00\x48\x8B\xB1", "xxxx?xxxx?xxxx?xxx", 0, idstr* result, unsigned int wwise_id);
 
+CREATE_CALLABLE_CLASS_SIGNATURE(CAkSrcFileBase__StartStream, void*, "\x40\x53\x48\x83\xEC\x20\xF6\x81\x82", "xxxxxxxxx", 0, void* in_bufSettings);
+
 CREATE_NORMAL_CALLABLE_SIGNATURE(AllocateRefCountId, int, "\x48\x89\x5C\x24\x00\x57\x48\x83\xEC\x00\x48\x8D\x3D\x00\x00\x00\x00\x48\x89\x7C\x24", "xxxx?xxxx?xxx????xxxx", 0)
 CREATE_NORMAL_CALLABLE_SIGNATURE(DecreaseRefCountById, int, "\x40\x53\x48\x83\xec\x20\x8b\xd9\x48\x8d\x0d****\xff\x15****\x48\x8b\x05****\x4c\x8d\x04\x9d\x00\x00\x00\x00\x41\x83\x04\x00\xff\x48\x8b\x05", "xxxxxxxxxxx????xx????xxx????xxxxxxxxxxxxxxxx", 0, int)
 


### PR DESCRIPTION
Prefetch sounds get stored both inside the banks and in `.stream` files; when overriding newer sounds with the PTADPCM codec with older IMA APDCM streams, an access violation will occur with a distinctive `AkTlsSetValue` name in the callstack. 

This is consistent with sounds of this type that are stored as PTADPCM in the bank, and overriden as IMA; if the sound is stored originally in the bank as IMA, there is no crashing. **However**, other issues still persist, like pitch changes (these even happen if the override file is in PTADPCM). This seems to have been happening since Wwise 2013, as evidenced in the comments/description of [this mod](https://modworkshop.net/mod/37604).

The easiest solution I've found is to simply flip the flag that Wwise uses to play the prefetch portion for overriden files, and let it always use the `.stream`. This works with both IMA and PT. The only caveat to this is that unreplaced prefetch sounds won't be prefetched the first time they play, though see the commit comments for the reason why.